### PR TITLE
feat(UserStoriesVotes): use Application Storage instead of a var

### DIFF
--- a/Sources/App/Application+UserStoriesVotes.swift
+++ b/Sources/App/Application+UserStoriesVotes.swift
@@ -1,0 +1,30 @@
+import Vapor
+
+extension Application {
+    var userStoriesVotes: [UserStory.IDValue: UserStoryVote] {
+        get { storage.get(UserStoryStorageKey.self) ?? [:] }
+        set {
+            storage.set(UserStoryStorageKey.self, to: newValue)
+            updateWebSockets()
+        }
+    }
+
+    var updateCallbacks: [UUID: () -> Void] {
+        get { storage.get(UpdateCallbacksStorageKey.self) ?? [:] }
+        set {
+            storage.set(UpdateCallbacksStorageKey.self, to: newValue)
+        }
+    }
+
+    func updateWebSockets() {
+        updateCallbacks.values.forEach { $0() }
+    }
+}
+
+struct UserStoryStorageKey: StorageKey {
+    typealias Value = [UserStory.IDValue: UserStoryVote]
+}
+
+struct UpdateCallbacksStorageKey: StorageKey {
+    typealias Value = [UUID: () -> Void]
+}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -21,7 +21,7 @@ public func configure(_ app: Application) throws {
         #endif
     } else if let databaseURL = Environment.get("DATABASE_URL"),
               var postgresConfig = PostgresConfiguration(url: databaseURL) {
-        postgresConfig.tlsConfiguration = .forClient(certificateVerification: .none)
+        postgresConfig.tlsConfiguration = .makeClientConfiguration()
         app.databases.use(.postgres(
             configuration: postgresConfig
         ), as: .psql)

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -22,6 +22,7 @@ public func configure(_ app: Application) throws {
     } else if let databaseURL = Environment.get("DATABASE_URL"),
               var postgresConfig = PostgresConfiguration(url: databaseURL) {
         postgresConfig.tlsConfiguration = .makeClientConfiguration()
+        postgresConfig.tlsConfiguration?.certificateVerification = .none
         app.databases.use(.postgres(
             configuration: postgresConfig
         ), as: .psql)

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -1,20 +1,6 @@
 import Fluent
 import Vapor
 
-// TODO: this should be changed to be a real Redux like store
-// (See https://github.com/renaudjenny/steamScrum/issues/29)
-final class AppStore {
-    var userStoriesVotes: [UserStory.IDValue: UserStoryVote] = [:] {
-        didSet { updateCallbacks.values.forEach { $0() } }
-    }
-
-    var updateCallbacks: [UUID: () -> Void] = [:]
-
-    func updateWebSockets() {
-        updateCallbacks.forEach { (key, callback) in callback() }
-    }
-}
-
 func routes(_ app: Application) throws {
     app.get { req in
         RefinementSession.query(on: req.db).sort(\.$date, .descending).all().map {
@@ -24,5 +10,5 @@ func routes(_ app: Application) throws {
 
     try app.register(collection: RefinementSessionController())
     try app.register(collection: UserStoryController())
-    try app.register(collection: UserStoryVoteController(store: AppStore()))
+    try app.register(collection: UserStoryVoteController())
 }


### PR DESCRIPTION
* It seems to be more appropriate to use the Application.Storage instead
  of a var to get and set values through the application. This will also
  remove a lot of warnings during tests.

* Fix #29